### PR TITLE
feat: add subtle under-construction banner

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,3 +1,23 @@
+.constructionBanner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px;
+  background: rgba(255, 180, 0, 0.08);
+  border: 1px solid rgba(255, 180, 0, 0.25);
+  color: #ffb400;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  backdrop-filter: blur(4px);
+  width: fit-content;
+}
+
+.constructionBanner p {
+  margin: 0;
+  opacity: 0.9;
+}
+
 .main {
   display: flex;
   flex-direction: column;

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -11,7 +11,7 @@
   letter-spacing: 0.02em;
   backdrop-filter: blur(4px);
   width: fit-content;
-}
+} 
 
 .constructionBanner p {
   margin: 0;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,6 +58,11 @@ export default function Home() {
 
   return (
     <main className={styles.main}>
+      <div className={styles.constructionBanner}>
+        <span>🚧</span>
+        <p>We&apos;re making some improvements — back soon!</p>
+        <span>🚧</span>
+      </div>
       <ToastContainer
         hideProgressBar={true}
         autoClose={3000}


### PR DESCRIPTION
Adds a small amber banner at the top of the page:

🚧 We're making some improvements — back soon! 🚧

- Warm amber color, semi-transparent with backdrop blur — fits the dark theme
- Sits above the header, doesn't interfere with existing layout
- Easy to remove when the site is back up (just delete the banner div + CSS class)